### PR TITLE
Add /resources/lang/* to PHPCS Ignore

### DIFF
--- a/tools/git-templates/hooks/pre-commit
+++ b/tools/git-templates/hooks/pre-commit
@@ -45,7 +45,7 @@ then
 #	 /usr/local/bin/phpmd $FILES html cleancode,codesize,controversial,design,naming,unusedcode --reportfile coverage/phpmd.html
 
 	echo "Running Code Sniffer..."
-    $HOME/.composer/vendor/bin/phpcs --ignore=*/tests/*,*/database/* --standard=SPRD-PSR2 --encoding=utf-8 -n -p $FILES
+    $HOME/.composer/vendor/bin/phpcs --ignore=*/database/*,*/resources/lang/* --standard=SPRD-PSR2 --encoding=utf-8 -n -p $FILES
 
 	if [ $? != 0 ]
 	then


### PR DESCRIPTION
We don't want to fix language files as they are generated by the Laravel Translation Manager.
However we should be checking the tests folder as they should be formatted according to the coding standards.